### PR TITLE
修复指针和溢出问题

### DIFF
--- a/src/core/memory/kmalloc.c
+++ b/src/core/memory/kmalloc.c
@@ -41,10 +41,6 @@ void *sbrk(int incr) { //内核堆扩容措施
     return prev_break;
 }
 
-static void morecore();
-
-static int findbucket();
-
 union overhead {
     union overhead *ov_next;    /* when free */
     struct {
@@ -73,6 +69,10 @@ static int pagesz;            /* page size */
 static int pagebucket;            /* page size bucket */
 
 #define    ASSERT(p)
+
+static void morecore(int bucket);
+
+static int findbucket(union overhead *freep, int srchlen);
 
 void *kmalloc(size_t nbytes) {
     register union overhead *op;

--- a/src/core/memory/page.c
+++ b/src/core/memory/page.c
@@ -26,28 +26,28 @@ static void set_frame(uint32_t frame_addr) { //设置物理块为占用
     uint32_t frame = frame_addr / PAGE_SIZE;
     uint32_t idx = INDEX_FROM_BIT(frame);
     uint32_t off = OFFSET_FROM_BIT(frame);
-    frames[idx] |= (0x1 << off);
+    frames[idx] |= (0x1U << off);
 }
 
 static void clear_frame(uint32_t frame_addr) { //释放物理块
     uint32_t frame = frame_addr / PAGE_SIZE;
     uint32_t idx = INDEX_FROM_BIT(frame);
     uint32_t off = OFFSET_FROM_BIT(frame);
-    frames[idx] &= ~(0x1 << off);
+    frames[idx] &= ~(0x1U << off);
 }
 
 static uint32_t test_frame(uint32_t frame_addr) {
     uint32_t frame = frame_addr / PAGE_SIZE;
     uint32_t idx = INDEX_FROM_BIT(frame);
     uint32_t off = OFFSET_FROM_BIT(frame);
-    return (frames[idx] & (0x1 << off));
+    return (frames[idx] & (0x1U << off));
 }
 
 uint32_t first_frame() { //获取第一个空闲物理块
     for (int i = 0; i < INDEX_FROM_BIT(0xFFFFFFFF / PAGE_SIZE); i++) {
         if (frames[i] != 0xffffffff) {
             for (int j = 0; j < 32; j++) {
-                uint32_t toTest = 0x1 << j;
+                uint32_t toTest = 0x1U << j;
                 if (!(frames[i] & toTest)) {
                     return i * 4 * 8 + j;
                 }

--- a/src/driver/pci/pci.c
+++ b/src/driver/pci/pci.c
@@ -188,7 +188,7 @@ uint32_t pci_dev_read32(pci_device_t* pdev, uint16_t offset) {
 }
 
 uint32_t read_pci(uint8_t bus, uint8_t device, uint8_t function, uint8_t registeroffset) {
-    uint32_t id = 1 << 31 | ((bus & 0xff) << 16) | ((device & 0x1f) << 11) |
+    uint32_t id = 1U << 31 | ((bus & 0xff) << 16) | ((device & 0x1f) << 11) |
                   ((function & 0x07) << 8) | (registeroffset & 0xfc);
     io_out32(PCI_COMMAND_PORT, id);
     uint32_t result = io_in32(PCI_DATA_PORT);

--- a/src/driver/video/vbe.c
+++ b/src/driver/video/vbe.c
@@ -1,34 +1,29 @@
 #include "video.h"
 
-video_area_t *videoArea;
 uint32_t width;
 uint32_t height;
 uint32_t *screen;
 
-void vbe_clear(uint32_t color){
-    width = videoArea->width;
-    height = videoArea->height;
-    screen = videoArea->screen;
-    for (uint32_t i = 0; i < (width * (height)); i++) {
-        screen[i] = color;
-    }
+static video_area_t videoArea;
+
+void vbe_clear(uint32_t color) {
+  width = videoArea.width;
+  height = videoArea.height;
+  screen = videoArea.screen;
+  for (uint32_t i = 0; i < (width * (height)); i++) {
+    screen[i] = color;
+  }
 }
 
-uint32_t *get_vbe_screen(){
-    return videoArea->screen;
-}
+uint32_t *get_vbe_screen() { return videoArea.screen; }
 
-uint32_t get_vbe_width(){
-    return videoArea->width;
-}
+uint32_t get_vbe_width() { return videoArea.width; }
 
-uint32_t get_vbe_height(){
-    return videoArea->height;
-}
+uint32_t get_vbe_height() { return videoArea.height; }
 
-void init_vbe(multiboot_t *multiboot){
-    screen = videoArea->screen = (uint32_t*)multiboot->framebuffer_addr;
-    width = videoArea->width = multiboot->framebuffer_width;
-    height = videoArea->height = multiboot->framebuffer_height;
-    vbe_clear(0xc6c6c6);
+void init_vbe(multiboot_t *multiboot) {
+  screen = videoArea.screen = (uint32_t *)multiboot->framebuffer_addr;
+  width = videoArea.width = multiboot->framebuffer_width;
+  height = videoArea.height = multiboot->framebuffer_height;
+  vbe_clear(0xc6c6c6);
 }

--- a/xmake.lua
+++ b/xmake.lua
@@ -1,38 +1,28 @@
 set_project("MdrOS")
 
 add_rules("mode.debug", "mode.release")
-add_requires("zig")
-add_requires("nasm")
+add_requires("zig", "nasm")
 
-set_languages("c99")
-set_arch("x86")
-
--- set_optimize("none")
--- set_policy("build.optimization.lto", true)
-
-target("asm")
-    set_kind("object")
-    set_toolchains("nasm")
-
-    add_files("src/**/*.asm")
-    add_asflags("-f", "elf32", {force = true})
+set_optimize("none")
 
 target("kernel")
     set_kind("binary")
-    add_deps("asm")
-    set_toolchains("@zig")
+    set_languages("c23")
+    set_toolchains("zig", "nasm")
 
     add_linkdirs("lib")
     add_includedirs("src/include")
 
     add_links("os_terminal")
-    add_files("src/**/*.c")
+    add_files("src/**/*.asm", "src/**/*.c")
 
+    add_asflags("-f", "elf32", {force = true})
     add_cflags("-target x86-freestanding", {force = true})
     add_ldflags("-target x86-freestanding", {force = true})
 
     add_ldflags("-T", "linker.ld", {force = true})
     add_cflags("-Wno-macro-redefined", "-Wno-int-conversion", {force = true})
+    add_cflags("-Wno-incompatible-pointer-types", {force = true})
 
 target("iso")
     set_kind("phony")


### PR DESCRIPTION
### 更改前：达咩

只有gcc能跑出ost，clang和zig都不行。

### 第一个问题：写入videoArea这个野指针（它从未被初始化过）
<img src="https://github.com/user-attachments/assets/7909d1cf-b8a0-4fca-83f9-91544149468f" alt="8274d3165b687fd190b1b15f73dd2093" width="350"/>

改成普通结构体后成功初始化vbe并刷新屏幕颜色。

### 第二个问题：有符号溢出，0x1的左移改成0x1U后解决
<img src="https://github.com/user-attachments/assets/fd0b17bf-e18a-4418-abd8-5dc4b67cdf86" alt="27a70e09116b9dc127319aeb4261081a" width="300"/>

<img src="https://github.com/user-attachments/assets/6613b32c-149f-4945-95f3-eec5ab839e5f" alt="fface887283b0b9eff2307551c0d67b6" width="300"/>

### 效果：修改后成功启动内核
<img src="https://github.com/user-attachments/assets/5f955ee3-0776-4986-8cc6-dca295afeaaf" alt="ce5c00ff9dc404d0a6a5d55d959eb671" width="450"/>